### PR TITLE
1.19.4 + improvements

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 }
 
 group = "me.noahvdaa.healthider"
-version = "1.0.1"
+version = "1.0.2"
 
 java {
     // Configure the java toolchain. This allows gradle to auto-provision JDK 17 on systems that only have JDK 8 installed for example.
@@ -19,7 +19,7 @@ java {
 dependencies {
     implementation("org.bstats:bstats-bukkit:3.0.0")
 
-    paperDevBundle("1.19.3-R0.1-SNAPSHOT")
+    paperDevBundle("1.19.4-R0.1-SNAPSHOT")
 }
 
 tasks {

--- a/src/main/java/me/noahvdaa/healthhider/HHConfig.java
+++ b/src/main/java/me/noahvdaa/healthhider/HHConfig.java
@@ -2,7 +2,7 @@ package me.noahvdaa.healthhider;
 
 import net.minecraft.world.entity.EntityType;
 
-import java.util.List;
+import java.util.Set;
 
-public record HHConfig(boolean enableBypassPermission, boolean whitelistMode, List<EntityType<?>> entities) {
+public record HHConfig(boolean enableBypassPermission, boolean whitelistMode, Set<EntityType<?>> entities) {
 }

--- a/src/main/java/me/noahvdaa/healthhider/HHHandler.java
+++ b/src/main/java/me/noahvdaa/healthhider/HHHandler.java
@@ -41,7 +41,7 @@ public class HHHandler extends MessageToMessageEncoder<Packet<?>> {
         }
 
         List<SynchedEntityData.DataValue<?>> packed = new ArrayList<>(packet.packedItems());
-        packed.replaceAll(dataValue -> {
+        packed.replaceAll((dataValue) -> {
             if (dataValue.id() == DATA_HEALTH_ID.getId()) {
                 float health = (float) dataValue.value();
                 float shownHealth;

--- a/src/main/java/me/noahvdaa/healthhider/HHHandler.java
+++ b/src/main/java/me/noahvdaa/healthhider/HHHandler.java
@@ -1,27 +1,22 @@
 package me.noahvdaa.healthhider;
 
-import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.MessageToByteEncoder;
+import io.netty.handler.codec.MessageToMessageEncoder;
 import net.minecraft.network.Connection;
-import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.protocol.Packet;
-import net.minecraft.network.protocol.PacketFlow;
 import net.minecraft.network.protocol.game.ClientboundSetEntityDataPacket;
+import net.minecraft.network.syncher.EntityDataSerializers;
 import net.minecraft.network.syncher.SynchedEntityData;
-import net.minecraft.server.MinecraftServer;
-import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static net.minecraft.world.entity.LivingEntity.DATA_HEALTH_ID;
 
-public class HHHandler extends MessageToByteEncoder<Packet<?>> {
-
-    private final MinecraftServer server = MinecraftServer.getServer();
+public class HHHandler extends MessageToMessageEncoder<Packet<?>> {
     private final HealthHider plugin;
 
     public HHHandler(HealthHider plugin) {
@@ -34,78 +29,59 @@ public class HHHandler extends MessageToByteEncoder<Packet<?>> {
     }
 
     @Override
-    protected void encode(ChannelHandlerContext ctx, Packet msg, ByteBuf out) {
-        FriendlyByteBuf buf = new FriendlyByteBuf(out);
+    protected void encode(ChannelHandlerContext ctx, Packet<?> msg, List<Object> out) {
         ClientboundSetEntityDataPacket packet = (ClientboundSetEntityDataPacket) msg;
 
         Connection connection = (Connection) ctx.pipeline().get("packet_handler");
         ServerPlayer player = connection.getPlayer();
 
-        if (packet.id() == player.getId()) {
+        if (!shouldObfuscate(player, packet)) {
+            out.add(msg);
+            return;
+        }
+
+        List<SynchedEntityData.DataValue<?>> packed = new ArrayList<>(packet.packedItems());
+        packed.replaceAll(dataValue -> {
+            if (dataValue.id() == DATA_HEALTH_ID.getId()) {
+                float health = (float) dataValue.value();
+                float shownHealth;
+                if (health <= 0.0F) {
+                    shownHealth = health;
+                } else {
+                    shownHealth = 1F;
+                }
+                return new SynchedEntityData.DataValue<> (dataValue.id(), EntityDataSerializers.FLOAT, shownHealth);
+            } else {
+                return dataValue;
+            }
+        });
+
+        out.add(new ClientboundSetEntityDataPacket(packet.id(), packed));
+    }
+
+    private boolean shouldObfuscate(ServerPlayer player, ClientboundSetEntityDataPacket packet) {
+        if (player == null || packet.id() == player.getId()) {
             // We don't want to hide our own health
-            this.writeId(ctx, packet, buf);
-            packet.write(buf);
-            return;
+            return false;
         }
 
-        Entity entity = null;
-        for (ServerLevel level : server.getAllLevels()) {
-            entity = level.getEntityLookup().get(packet.id());
-            if (entity != null) {
-                break;
-            }
-        }
+        Entity entity = player.getLevel().getEntityLookup().get(packet.id());
 
-        List<SynchedEntityData.DataValue<?>> packed = packet.packedItems();
-        SynchedEntityData.DataValue<?> healthValue = null;
-
-        int i = 0;
-        for (SynchedEntityData.DataValue<?> value : packed) {
-            if (value.id() == DATA_HEALTH_ID.getId()) {
-                healthValue = value;
-                break;
-            }
-            i++;
-        }
-
-        if (healthValue == null || (entity != null && !(entity instanceof LivingEntity))) {
+        if (!(entity instanceof LivingEntity)) {
             // Only living entities have health
-            this.writeId(ctx, packet, buf);
-            packet.write(buf);
-            return;
+            return false;
         }
 
         HHConfig config = plugin.configuration();
-        if (entity != null && config.entities().contains(entity.getType()) != config.whitelistMode()) {
+        if (config.entities().contains(entity.getType()) != config.whitelistMode()) {
             // We don't need to censor this entity
-            this.writeId(ctx, packet, buf);
-            packet.write(buf);
-            return;
+            return false;
         }
 
         if (config.enableBypassPermission() && player.getBukkitEntity().hasPermission("healthider.bypass")) {
-            this.writeId(ctx, packet, buf);
-            packet.write(buf);
-            return;
+            return false;
         }
 
-        float health = (float) healthValue.value();
-        float shownHealth;
-        if (health <= 0.0F) {
-            shownHealth = health;
-        } else {
-            shownHealth = 1F;
-        }
-
-        SynchedEntityData.DataValue<?> dataValue = new SynchedEntityData.DataValue<>(DATA_HEALTH_ID.getId(), DATA_HEALTH_ID.getSerializer(), shownHealth);
-
-        packed.set(i, dataValue);
-        this.writeId(ctx, packet, buf);
-        packet.write(buf);
+        return true;
     }
-
-    private void writeId(final ChannelHandlerContext ctx, final Packet<?> packet, final FriendlyByteBuf buf) {
-        buf.writeVarInt(ctx.channel().attr(Connection.ATTRIBUTE_PROTOCOL).get().getPacketId(PacketFlow.CLIENTBOUND, packet));
-    }
-
 }

--- a/src/main/java/me/noahvdaa/healthhider/HealthHider.java
+++ b/src/main/java/me/noahvdaa/healthhider/HealthHider.java
@@ -26,7 +26,7 @@ public final class HealthHider extends JavaPlugin {
 
         this.loadConfig();
 
-        ChannelInitializeListenerHolder.addListener(LISTENER_KEY, (channel) -> channel.pipeline().addAfter("packet_handler", "healthider_handler", new HHHandler(this)));
+        ChannelInitializeListenerHolder.addListener(LISTENER_KEY, (channel) -> channel.pipeline().addBefore("unbundler", "healthider_handler", new HHHandler(this)));
 
         Metrics metrics = new Metrics(this, BSTATS_ID);
         metrics.addCustomChart(new SimplePie("bypass-permission", () -> this.configuration.enableBypassPermission() ? "Yes" : "No"));
@@ -55,7 +55,7 @@ public final class HealthHider extends JavaPlugin {
                 continue;
             }
 
-            EntityType<?> type = BuiltInRegistries.ENTITY_TYPE.get(key);
+            EntityType<?> type = BuiltInRegistries.ENTITY_TYPE.getOptional(key).orElse(null);
             if (type == null) {
                 this.getLogger().warning("Unknown entity type '" + entityName + "'");
                 continue;

--- a/src/main/java/me/noahvdaa/healthhider/HealthHider.java
+++ b/src/main/java/me/noahvdaa/healthhider/HealthHider.java
@@ -12,7 +12,9 @@ import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 public final class HealthHider extends JavaPlugin {
 
@@ -47,7 +49,7 @@ public final class HealthHider extends JavaPlugin {
             listMode = "blacklist";
         }
 
-        List<EntityType<?>> entities = new ArrayList<>();
+        Set<EntityType<?>> entities = new HashSet<>();
         for (String entityName : config.getStringList("entities")) {
             ResourceLocation key = ResourceLocation.tryParse(entityName);
             if (key == null) {


### PR DESCRIPTION
- Updated to 1.19.4
- Use MessageToMessageEncoder
- Only try to find entity in the current world of the player
- Clone the packet
- List -> Set
- Don't try to obfuscate health if entity is not found (resulted in CCE before)